### PR TITLE
Fix response "query string malformed"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # osrm
 OSRM Api wrapper for Go
+
+Example usage:
+
+```go
+package main
+
+import (
+	"github.com/maddevsio/osrm"
+	"log"
+)
+
+func main() {
+	osrmapi := osrm.NewClient("http://127.0.0.1:5000")
+	options := osrm.RouteOptions{}
+	options.Profile = "driving"
+	options.Locations = []osrm.Location{
+		{Lon: 13.388860, Lat: 52.517037},
+		{Lat: 13.397634, Lon: 52.529407},
+	}
+	b, err := osrmapi.RouteTo(options)
+	log.Printf("%s", b)
+	log.Printf("%v", err)
+}
+```

--- a/osrm.go
+++ b/osrm.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -58,6 +59,28 @@ func (oc *Client) buildRouteUrl(options RouteOptions) (string, error) {
 	return url, nil
 }
 
+func (oc *Client) processOptions(q *url.Values, options RouteOptions) {
+	if options.Alternatives != "" {
+		q.Add("alternatives", options.Alternatives)
+	}
+	if options.Steps != "" {
+		q.Add("steps", options.Steps)
+	}
+
+	if options.Annotations != "" {
+		q.Add("annotations", options.Annotations)
+	}
+	if options.Geometries != "" {
+		q.Add("geometries", options.Geometries)
+	}
+	if options.Overview != "" {
+		q.Add("overview", options.Overview)
+	}
+	if options.ContinueStraight != "" {
+		q.Add("continue_straight", options.ContinueStraight)
+	}
+}
+
 func (oc *Client) RouteTo(options RouteOptions) ([]byte, error) {
 	url, err := oc.buildRouteUrl(options)
 	if err != nil {
@@ -68,12 +91,8 @@ func (oc *Client) RouteTo(options RouteOptions) ([]byte, error) {
 		return nil, err
 	}
 	q := req.URL.Query()
-	q.Add("alternatives", options.Alternatives)
-	q.Add("steps", options.Steps)
-	q.Add("annotations", options.Annotations)
-	q.Add("geometries", options.Geometries)
-	q.Add("overview", options.Overview)
-	q.Add("continue_straight", options.ContinueStraight)
+	oc.processOptions(&q, options)
+
 	req.URL.RawQuery = q.Encode()
 	resp, err := oc.Client.Do(req)
 	if err != nil {

--- a/osrm_test.go
+++ b/osrm_test.go
@@ -1,8 +1,9 @@
 package osrm
 
 import "testing"
+import "net/http"
 
-func TestBuildRoute(t *testing.T) {
+func TestBuildRouteUrl(t *testing.T) {
 	c := NewClient("http://example.com")
 	url, err := c.buildRouteUrl(RouteOptions{
 		Profile: "driving",
@@ -22,5 +23,21 @@ func TestBuildRoute(t *testing.T) {
 	}
 	if url != "http://example.com/route/v1/driving/74.595532,42.878473;74.587990,42.873764" {
 		t.Error(url)
+	}
+}
+
+func TestQueryIncludesOnlyRouteOptionsThatAreExplicitlySet(t *testing.T) {
+	c := NewClient("http://example.com")
+	req, err := http.NewRequest("GET", "http://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q := req.URL.Query()
+	c.processOptions(&q, RouteOptions{
+		Steps: "true",
+	})
+	if q.Encode() != "steps=true" {
+		t.Error(q.Encode())
 	}
 }


### PR DESCRIPTION
When some routeOptions are not specified, the `RouteTo` method returns `{"message":"Query string malformed close to position 71","code":"InvalidQuery"}`

To reproduce the error run this example against the current master branch
```go
package main

import (
	"github.com/maddevsio/osrm"
	"log"
)

func main() {
	osrmapi := osrm.NewClient("http://127.0.0.1:5000")
	options := osrm.RouteOptions{}
	options.Profile = "driving"
	options.Locations = []osrm.Location{
		{Lon: 13.388860, Lat: 52.517037},
		{Lat: 13.397634, Lon: 52.529407},
	}
	b, err := osrmapi.RouteTo(options)
	log.Printf("%s", b)
	log.Printf("%v", err)
}
```

